### PR TITLE
fix: ensure Prisma client is available in production Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,10 @@ COPY --from=builder --chown=nextjs:nodejs /app/dist ./dist
 COPY --from=builder --chown=nextjs:nodejs /app/prisma ./prisma
 COPY --from=builder --chown=nextjs:nodejs /app/package*.json ./
 
+# Copy generated Prisma client from builder stage
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/@prisma/client ./node_modules/@prisma/client
+
 # Switch to non-root user
 USER nextjs
 


### PR DESCRIPTION
- Copy generated .prisma/client from builder stage to production stage
- Copy @prisma/client from builder stage to production stage
- Fixes 'Cannot find module .prisma/client/default' runtime error
- Prisma client is now properly available for database operations

﻿## Summary

## Type

- [ ] Chore (build/infra)
- [ ] Fix
- [ ] Feature
- [ ] Docs

## Checklist

- [ ] Lint/format pass locally
- [ ] CI green
- [ ] If config changed, README/ENV updated
