### PR TITLE
fix: railway cli syntax for github actions deployment

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -21,12 +21,10 @@ jobs:
         run: npm install -g @railway/cli
 
       - name: Deploy to Railway (Production)
-        run: |
-          railway login --token ${{ secrets.RAILWAY_TOKEN }}
-          railway link --project ${{ secrets.RAILWAY_PRODUCTION_PROJECT_ID }}
-          railway up --service betmate-api-production
+        run: railway up --service betmate-api-production
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PRODUCTION_PROJECT_ID }}
           NODE_ENV: production
           DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
           JWT_SECRET: ${{ secrets.PRODUCTION_JWT_SECRET }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -17,12 +17,10 @@ jobs:
         run: npm install -g @railway/cli
 
       - name: Deploy to Railway (Staging)
-        run: |
-          railway login --token ${{ secrets.RAILWAY_TOKEN }}
-          railway link --project ${{ secrets.RAILWAY_PROJECT_ID }}
-          railway up --service betmate-api-staging
+        run: railway up --service betmate-api-staging
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
           NODE_ENV: staging
           DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
           JWT_SECRET: ${{ secrets.STAGING_JWT_SECRET }}


### PR DESCRIPTION
- Remove railway login command (not needed, uses RAILWAY_TOKEN env var)
- Remove railway link command (uses RAILWAY_PROJECT_ID env var instead)
- Simplify to just railway up with environment variables
- Railway CLI automatically uses RAILWAY_TOKEN and RAILWAY_PROJECT_ID from env


﻿## Summary

## Type

- [ ] Chore (build/infra)
- [ ] Fix
- [ ] Feature
- [ ] Docs

## Checklist

- [ ] Lint/format pass locally
- [ ] CI green
- [ ] If config changed, README/ENV updated
