### PR TITLE
fix: remove interactive railway login for non-interactive CI

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -22,14 +22,11 @@ jobs:
 
       - name: Deploy to Railway (Production)
         run: |
-          echo "Authenticating with Railway..."
-          railway login
-          echo "Linking to project..."
-          railway link ${{ secrets.RAILWAY_PRODUCTION_PROJECT_ID }}
-          echo "Deploying service..."
+          echo "Deploying to Railway production..."
           railway up --service betmate-api-production
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PRODUCTION_PROJECT_ID }}
           NODE_ENV: production
           DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
           JWT_SECRET: ${{ secrets.PRODUCTION_JWT_SECRET }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,14 +18,11 @@ jobs:
 
       - name: Deploy to Railway (Staging)
         run: |
-          echo "Authenticating with Railway..."
-          railway login
-          echo "Linking to project..."
-          railway link ${{ secrets.RAILWAY_PROJECT_ID }}
-          echo "Deploying service..."
+          echo "Deploying to Railway staging..."
           railway up --service betmate-api-staging
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          RAILWAY_PROJECT_ID: ${{ secrets.RAILWAY_PROJECT_ID }}
           NODE_ENV: staging
           DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
           JWT_SECRET: ${{ secrets.STAGING_JWT_SECRET }}


### PR DESCRIPTION
- Remove 'railway login' command that fails in GitHub Actions
- Railway CLI automatically authenticates when RAILWAY_TOKEN is provided
- Add RAILWAY_PROJECT_ID environment variables for project identification
- Simplify deployment to only use 'railway up' command

Fixes the 'Cannot login in non-interactive mode' error

🤖 Generated with [Claude Code](https://claude.ai/code)

﻿## Summary

## Type

- [ ] Chore (build/infra)
- [ ] Fix
- [ ] Feature
- [ ] Docs

## Checklist

- [ ] Lint/format pass locally
- [ ] CI green
- [ ] If config changed, README/ENV updated
