### PR TITLE
fix: remove interactive railway login causing deployment failures

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -22,11 +22,9 @@ jobs:
 
       - name: Deploy to Railway (Production)
         run: |
-          echo "Authenticating with Railway..."
-          railway login
-          echo "Linking to project..."
+          echo "Linking to Railway project..."
           railway link ${{ secrets.RAILWAY_PRODUCTION_PROJECT_ID }}
-          echo "Deploying service..."
+          echo "Deploying to Railway production..."
           railway up --service betmate-api-production
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,11 +18,9 @@ jobs:
 
       - name: Deploy to Railway (Staging)
         run: |
-          echo "Authenticating with Railway..."
-          railway login
-          echo "Linking to project..."
+          echo "Linking to Railway project..."
           railway link ${{ secrets.RAILWAY_PROJECT_ID }}
-          echo "Deploying service..."
+          echo "Deploying to Railway staging..."
           railway up --service betmate-api-staging
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
- Remove 'railway login' command that fails with 'Cannot login in non-interactive mode'
- Railway CLI automatically authenticates when RAILWAY_TOKEN environment variable is present
- Keep 'railway link' command for proper project identification
- Resolves deployment authentication issues in GitHub Actions

🤖 Generated with [Claude Code](https://claude.ai/code)

﻿## Summary

## Type

- [ ] Chore (build/infra)
- [ ] Fix
- [ ] Feature
- [ ] Docs

## Checklist

- [ ] Lint/format pass locally
- [ ] CI green
- [ ] If config changed, README/ENV updated
