### PR TITLE
fix: simplify Railway deployment by removing problematic link command

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Deploy to Railway (Production)
         run: |
-          echo "Linking to Railway project..."
-          railway link ${{ secrets.RAILWAY_PRODUCTION_PROJECT_ID }}
           echo "Deploying to Railway production..."
           railway up --service betmate-api-production
         env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Deploy to Railway (Staging)
         run: |
-          echo "Linking to Railway project..."
-          railway link ${{ secrets.RAILWAY_PROJECT_ID }}
           echo "Deploying to Railway staging..."
           railway up --service betmate-api-staging
         env:


### PR DESCRIPTION
- Remove 'railway link' command causing syntax errors
- Railway CLI uses RAILWAY_PROJECT_ID environment variable automatically
- Simplify to direct 'railway up' command with service specification
- Both RAILWAY_TOKEN and RAILWAY_PROJECT_ID are provided as env vars

🤖 Generated with [Claude Code](https://claude.ai/code)

﻿## Summary

## Type

- [ ] Chore (build/infra)
- [ ] Fix
- [ ] Feature
- [ ] Docs

## Checklist

- [ ] Lint/format pass locally
- [ ] CI green
- [ ] If config changed, README/ENV updated
