### PR TITLE
fix: use npm start in Dockerfile CMD for Railway compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,5 +56,5 @@ USER nextjs
 
 EXPOSE 4000
 
-# Apply DB migrations at container start, then run the app
-CMD ["sh", "-c", "npx prisma migrate deploy && node dist/index.js"]
+# Use npm start to run prestart hooks and the app
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
Changed Dockerfile CMD from direct node execution to npm start to ensure:
- Prestart scripts run properly (db migrations)
- Consistency with Railway configuration
- Proper module resolution and dependency loading

This fixes the MODULE_NOT_FOUND error occurring in Railway deployments.

🤖 Generated with [Claude Code](https://claude.ai/code)

﻿## Summary

## Type

- [ ] Chore (build/infra)
- [ ] Fix
- [ ] Feature
- [ ] Docs

## Checklist

- [ ] Lint/format pass locally
- [ ] CI green
- [ ] If config changed, README/ENV updated
