### PR TITLE
fix: move @betmate-ap/contracts to production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
     "pino": "^9.8.0",
     "pino-http": "^10.5.0",
     "pino-pretty": "^13.1.1",
-    "prisma": "^6.14.0"
+    "prisma": "^6.14.0",
+    "@betmate-ap/contracts": "^0.1.1"
   },
   "devDependencies": {
-    "@betmate-ap/contracts": "^0.1.1",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@eslint/js": "^9.33.0",


### PR DESCRIPTION
The GraphQL schema loader requires @betmate-ap/contracts at runtime. Moving from devDependencies to dependencies to fix MODULE_NOT_FOUND error for GraphQL schema loading in production deployments.

🤖 Generated with [Claude Code](https://claude.ai/code)

﻿## Summary

## Type

- [ ] Chore (build/infra)
- [ ] Fix
- [ ] Feature
- [ ] Docs

## Checklist

- [ ] Lint/format pass locally
- [ ] CI green
- [ ] If config changed, README/ENV updated
